### PR TITLE
Fix error with deserialization of ModifyMedia response

### DIFF
--- a/Bynder/Sdk/Service/Asset/AssetService.cs
+++ b/Bynder/Sdk/Service/Asset/AssetService.cs
@@ -152,7 +152,7 @@ namespace Bynder.Sdk.Service.Asset
         /// <returns>Check <see cref="IAssetService"/> for more information</returns>
         public Task ModifyMediaAsync(ModifyMediaQuery query)
         {
-            var request = new ApiRequest<string>
+            var request = new ApiRequest<object>
             {
                 Path = $"/api/v4/media/{query.MediaId}/",
                 HTTPMethod = HttpMethod.Post,

--- a/Bynder/Test/Service/Asset/AssetServiceTest.cs
+++ b/Bynder/Test/Service/Asset/AssetServiceTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Bynder. All rights reserved.
+// Copyright (c) Bynder. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
@@ -122,15 +122,15 @@ namespace Bynder.Test.Service.Asset
         public async Task ModifyMediaCallsRequestSenderWithValidRequest()
         {
             var apiRequestSender = new Mock<IApiRequestSender>();
-            var result = "";
-            apiRequestSender.Setup(sender => sender.SendRequestAsync(It.IsAny<Request<string>>()))
+            object result = new { message = "Accepted", statuscode = 202 };
+            apiRequestSender.Setup(sender => sender.SendRequestAsync(It.IsAny<Request<object>>()))
              .Returns(Task.FromResult(result));
             var assetService = new AssetService(apiRequestSender.Object);
             var modifyMediaQuery = new ModifyMediaQuery("mediaId");
             await assetService.ModifyMediaAsync(modifyMediaQuery);
 
             apiRequestSender.Verify(sender => sender.SendRequestAsync(
-                It.Is<Request<string>>(
+                It.Is<Request<object>>(
                     req => req.Path == $"/api/v4/media/{modifyMediaQuery.MediaId}/"
                     && req.HTTPMethod == HttpMethod.Post
                     && req.Query == modifyMediaQuery


### PR DESCRIPTION
When using the `ModifyMediaAsync` method, there is an error deserializing the response. 

> An error has occurred
> Unexpected character encountered while parsing value: {. Path '', line 1, position 1.
> at Newtonsoft.Json.JsonTextReader.ReadStringValue(ReadType readType)
> at Newtonsoft.Json.JsonTextReader.ReadAsString()
> at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)
> at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
> at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
> at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
> at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
> at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value)
> at Bynder.Sdk.Api.RequestSender.ApiRequestSender.<SendRequestAsync>d__8`1.MoveNext()

This fix changes the expected response type to fix the error. Since the response value is not used anyway, I've just used a generic object.