### PR TITLE
API-97 - add user agent to requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# General macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
 # Build results
 bin/
 obj/

--- a/Bynder/Sdk/Api/RequestSender/ApiRequestSender.cs
+++ b/Bynder/Sdk/Api/RequestSender/ApiRequestSender.cs
@@ -90,13 +90,21 @@ namespace Bynder.Sdk.Api.RequestSender
             }
 
             var httpRequest = CreateHttpRequest(request);
-            var responseString = await _httpSender.SendHttpRequest(httpRequest).ConfigureAwait(false);
-            if (!string.IsNullOrEmpty(responseString))
+            var response = await _httpSender.SendHttpRequest(httpRequest).ConfigureAwait(false);
+
+            var responseContent = response.Content;
+            if (response.Content == null)
             {
-                return JsonConvert.DeserializeObject<T>(responseString);
+                return default(T);
             }
 
-            return default(T);
+            var responseString = await responseContent.ReadAsStringAsync().ConfigureAwait(false);
+            if (string.IsNullOrEmpty(responseString))
+            {
+                return default(T);
+            }
+
+            return JsonConvert.DeserializeObject<T>(responseString);
         }
 
         private HttpRequestMessage CreateHttpRequest<T>(Requests.Request<T> request)

--- a/Bynder/Sdk/Api/RequestSender/ApiRequestSender.cs
+++ b/Bynder/Sdk/Api/RequestSender/ApiRequestSender.cs
@@ -27,6 +27,8 @@ namespace Bynder.Sdk.Api.RequestSender
         private SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
         private IHttpRequestSender _httpSender;
 
+        public const string TokenPath = "/v6/authentication/oauth2/token";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Sdk.Api.ApiRequestSender"/> class.
         /// </summary>
@@ -138,7 +140,7 @@ namespace Bynder.Sdk.Api.RequestSender
             {
                 Authenticated = false,
                 Query = query,
-                Path = $"/v6/authentication/oauth2/token",
+                Path = TokenPath,
                 HTTPMethod = HttpMethod.Post
             };
 

--- a/Bynder/Sdk/Api/RequestSender/ApiRequestSender.cs
+++ b/Bynder/Sdk/Api/RequestSender/ApiRequestSender.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Bynder.Sdk.Model;
 using Bynder.Sdk.Api.Requests;
-using Bynder.Sdk.Service;
 using Newtonsoft.Json;
 using Bynder.Sdk.Query.Decoder;
 using Bynder.Sdk.Query;

--- a/Bynder/Sdk/Api/RequestSender/HttpRequestSender.cs
+++ b/Bynder/Sdk/Api/RequestSender/HttpRequestSender.cs
@@ -15,16 +15,15 @@ namespace Bynder.Sdk.Api.RequestSender
         private readonly HttpClient _httpClient = new HttpClient();
 
         /// <summary>
-        /// Sends the HTTP request and returns the content as string.
+        /// Sends the HTTP request and returns its response.
         /// </summary>
         /// <returns>The HTTP request response.</returns>
         /// <param name="httpRequest">HTTP request.</param>
-        public async Task<string> SendHttpRequest(HttpRequestMessage httpRequest)
+        public async Task<HttpResponseMessage> SendHttpRequest(HttpRequestMessage httpRequest)
         {
-            var response = await _httpClient.SendAsync(httpRequest).ConfigureAwait(false);
-
+            HttpResponseMessage response = await _httpClient.SendAsync(httpRequest).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return response;
         }
 
         /// <summary>

--- a/Bynder/Sdk/Api/RequestSender/HttpRequestSender.cs
+++ b/Bynder/Sdk/Api/RequestSender/HttpRequestSender.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System.Net.Http;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Bynder.Sdk.Api.RequestSender
@@ -14,6 +15,11 @@ namespace Bynder.Sdk.Api.RequestSender
     {
         private readonly HttpClient _httpClient = new HttpClient();
 
+        public string UserAgent
+        {
+            get { return "bynder-c-sharp-sdk/" + Assembly.GetExecutingAssembly().GetName().Version.ToString(); }
+        }
+
         /// <summary>
         /// Sends the HTTP request and returns its response.
         /// </summary>
@@ -21,6 +27,7 @@ namespace Bynder.Sdk.Api.RequestSender
         /// <param name="httpRequest">HTTP request.</param>
         public async Task<HttpResponseMessage> SendHttpRequest(HttpRequestMessage httpRequest)
         {
+            httpRequest.Headers.Add("User-Agent", UserAgent);
             HttpResponseMessage response = await _httpClient.SendAsync(httpRequest).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             return response;

--- a/Bynder/Sdk/Api/RequestSender/HttpRequestSender.cs
+++ b/Bynder/Sdk/Api/RequestSender/HttpRequestSender.cs
@@ -20,7 +20,7 @@ namespace Bynder.Sdk.Api.RequestSender
         /// </summary>
         public string UserAgent
         {
-            get { return "bynder-c-sharp-sdk/" + Assembly.GetExecutingAssembly().GetName().Version.ToString(); }
+            get { return $"bynder-c-sharp-sdk/{Assembly.GetExecutingAssembly().GetName().Version.ToString()}"; }
         }
 
         /// <summary>

--- a/Bynder/Sdk/Api/RequestSender/HttpRequestSender.cs
+++ b/Bynder/Sdk/Api/RequestSender/HttpRequestSender.cs
@@ -15,6 +15,9 @@ namespace Bynder.Sdk.Api.RequestSender
     {
         private readonly HttpClient _httpClient = new HttpClient();
 
+        /// <summary>
+        /// User-Agent header we add to each request.
+        /// </summary>
         public string UserAgent
         {
             get { return "bynder-c-sharp-sdk/" + Assembly.GetExecutingAssembly().GetName().Version.ToString(); }
@@ -28,7 +31,7 @@ namespace Bynder.Sdk.Api.RequestSender
         public async Task<HttpResponseMessage> SendHttpRequest(HttpRequestMessage httpRequest)
         {
             httpRequest.Headers.Add("User-Agent", UserAgent);
-            HttpResponseMessage response = await _httpClient.SendAsync(httpRequest).ConfigureAwait(false);
+            var response = await _httpClient.SendAsync(httpRequest).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             return response;
         }

--- a/Bynder/Sdk/Api/RequestSender/IHttpRequestSender.cs
+++ b/Bynder/Sdk/Api/RequestSender/IHttpRequestSender.cs
@@ -14,10 +14,10 @@ namespace Bynder.Sdk.Api.RequestSender
     internal interface IHttpRequestSender : IDisposable
     {
         /// <summary>
-        /// Sends the HTTP request and returns the content as string.
+        /// Sends the HTTP request and returns its response.
         /// </summary>
         /// <returns>The HTTP request response.</returns>
         /// <param name="httpRequest">HTTP request.</param>
-        Task<string> SendHttpRequest(HttpRequestMessage httpRequest);
+        Task<HttpResponseMessage> SendHttpRequest(HttpRequestMessage httpRequest);
     }
 }

--- a/Bynder/Sdk/Bynder.Sdk.csproj
+++ b/Bynder/Sdk/Bynder.Sdk.csproj
@@ -6,10 +6,29 @@
     <Company>Bynder</Company>
     <Product>Bynder.Sdk</Product>
     <Copyright>Copyright © Bynder</Copyright>
+    <PackOnBuild>true</PackOnBuild>
+    <PackageVersion>2.2.0</PackageVersion>
+    <Authors>BynderDevops</Authors>
+    <Description>The main goal of this SDK is to speed up the integration of Bynder customers who use C# making it easier to connect to the Bynder API (http://docs.bynder.apiary.io/) and executing requests on it.</Description>
+    <PackageIconUrl>https://bynder.com/static/3.0/img/favicon-black.ico</PackageIconUrl>
+    <NeutralLanguage>en</NeutralLanguage>
+    <PackageLicenseUrl>https://github.com/Bynder/bynder-c-sharp-sdk/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <Owners>BynderDevops</Owners>
+    <PackageProjectUrl>https://github.com/Bynder/bynder-c-sharp-sdk</PackageProjectUrl>
+    <PackageReleaseNotes>Adds the SDK's name and version to each request in the User-Agent header, to enable better insight in the Bynder API usage.</PackageReleaseNotes>
+    <Summary>The main goal of this SDK is to speed up the integration of Bynder customers who use C# making it easier to connect to the Bynder API (http://docs.bynder.apiary.io/) and executing requests on it.</Summary>
+    <PackageTags>Bynder API C# SDK</PackageTags>
+    <Title>Bynder.Sdk</Title>
+    <PackageId>Bynder.Sdk</PackageId>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bynder/Test/Api/RequestSender/ApiRequestSenderTest.cs
+++ b/Bynder/Test/Api/RequestSender/ApiRequestSenderTest.cs
@@ -102,7 +102,6 @@ namespace Bynder.Test.Api.RequestSender
         [Fact]
         public async Task WhenRequestIsGetThenParametersAreAddedToUrl()
         {
-            //await SendRequest(true, HttpMethod.Get)
             using (var apiRequestSender = CreateApiRequestSender(true))
             {
                 var apiRequest = new ApiRequest<bool>
@@ -128,80 +127,6 @@ namespace Bynder.Test.Api.RequestSender
                 ), Times.Once);
             }
         }
-
-        //private asynv Task SendRequest(
-        //    bool hasValidCredentials,
-        //    HttpMethod httpMethod
-        //)
-        //{
-        //    var httpSenderMock = new Mock<IHttpRequestSender>();
-        //    var query = new StubQuery
-        //    {
-        //        Item1 = "Value"
-        //    };
-        //    var accessToken = "access_token";
-
-        //    using (ApiRequestSender apiRequestSender = new ApiRequestSender(
-        //        new Configuration
-        //        {
-        //            BaseUrl = new Uri("https://example.bynder.com"),
-        //        },
-        //        GetCredentials(hasValidCredentials, accessToken),
-        //        httpSenderMock.Object
-        //    ))
-        //    {
-        //        var apiRequest = new ApiRequest<bool>
-        //        {
-        //            Path = "/fake/api",
-        //            HTTPMethod = httpMethod,
-        //            Query = query
-        //        };
-
-        //        await apiRequestSender.SendRequestAsync(apiRequest);
-
-        //        //httpSenderMock.Verify(sender => sender.SendHttpRequest(
-        //        //    It.Is<HttpRequestMessage>(
-        //        //        req => req.RequestUri.PathAndQuery.Contains("/fake/api")
-        //        //        && req.Method == httpMethod
-        //        //        && req.Headers.Authorization.ToString() == $"Bearer {accessToken}"
-        //        //        && req.Content.ReadAsStringAsync().Result.Contains("Item1=Value")
-        //        //    )));
-        //        //httpSenderMock.Verify(sender => sender.SendHttpRequest(
-        //        //    It.Is<HttpRequestMessage>(
-        //        //        req => req.RequestUri.PathAndQuery.Contains("/fake/api")
-        //        //        && req.Method == HttpMethod.Get
-        //        //        && req.Headers.Authorization.ToString() == $"Bearer {accessToken}"
-        //        //        && req.RequestUri.Query.Contains("Item1=Value")
-        //        //    )));
-        //        //httpSenderMock.Verify(sender => sender.SendHttpRequest(
-        //        //    It.Is<HttpRequestMessage>(
-        //        //        req => req.RequestUri.PathAndQuery.Contains("/fake/api")
-        //        //        && req.Method == HttpMethod.Get
-        //        //        && req.Headers.Authorization.ToString() == $"Bearer {accessToken}"
-        //        //        && req.RequestUri.Query.Contains("Item1=Value")
-        //        //    )));
-
-
-
-        //        ////httpSenderMock.Verify(sender => sender.SendHttpRequest(
-        //        ////    It.IsAny<HttpRequestMessage>()
-        //        ////), Times.Once);
-        //        //httpSenderMock.Verify(sender => sender.SendHttpRequest(
-        //        //    It.Is<HttpRequestMessage>(
-        //        //        req => req.RequestUri.PathAndQuery.Contains("/oauth2/token")
-        //        //        && req.Method == HttpMethod.Post
-        //        //    )
-        //        //), Times.Once);
-
-        //        //httpSenderMock.Verify(sender => sender.SendHttpRequest(
-        //        //    It.IsAny<HttpRequestMessage>()
-        //        //), Times.Exactly(2));
-
-        //        //httpSenderMock.Verify(sender => sender.SendHttpRequest(
-        //        //    It.IsAny<HttpRequestMessage>()
-        //        //), Times.Once);
-        //    }
-        //}
 
         private IApiRequestSender CreateApiRequestSender(bool hasValidCredentials)
         {

--- a/Bynder/Test/Api/RequestSender/ApiRequestSenderTest.cs
+++ b/Bynder/Test/Api/RequestSender/ApiRequestSenderTest.cs
@@ -15,7 +15,7 @@ namespace Bynder.Test.Api.RequestSender
 {
     public class ApiRequestSenderTest
     {
-        private const string ACCES_TOKEN = "access_token";
+        private const string AccessToken = "access_token";
 
         private Mock<IHttpRequestSender> httpSenderMock;
         private StubQuery query;
@@ -51,7 +51,7 @@ namespace Bynder.Test.Api.RequestSender
                     It.Is<HttpRequestMessage>(req =>
                         req.RequestUri.PathAndQuery.Contains("/fake/api")
                         && req.Method == HttpMethod.Post
-                        && req.Headers.Authorization.ToString() == $"Bearer {ACCES_TOKEN}"
+                        && req.Headers.Authorization.ToString() == $"Bearer {AccessToken}"
                         && req.Content.ReadAsStringAsync().Result.Contains("Item1=Value")
                     )
                 ));
@@ -88,7 +88,7 @@ namespace Bynder.Test.Api.RequestSender
                     It.Is<HttpRequestMessage>(
                         req => req.RequestUri.PathAndQuery.Contains("/fake/api")
                         && req.Method == HttpMethod.Get
-                        && req.Headers.Authorization.ToString() == $"Bearer {ACCES_TOKEN}"
+                        && req.Headers.Authorization.ToString() == $"Bearer {AccessToken}"
                         && req.RequestUri.Query.Contains("Item1=Value")
                     )
                 ));
@@ -117,7 +117,7 @@ namespace Bynder.Test.Api.RequestSender
                     It.Is<HttpRequestMessage>(
                         req => req.RequestUri.PathAndQuery.Contains("/fake/api")
                         && req.Method == HttpMethod.Get
-                        && req.Headers.Authorization.ToString() == $"Bearer {ACCES_TOKEN}"
+                        && req.Headers.Authorization.ToString() == $"Bearer {AccessToken}"
                         && req.RequestUri.Query.Contains("Item1=Value")
                     )
                 ));
@@ -150,7 +150,7 @@ namespace Bynder.Test.Api.RequestSender
 
             credentialsMock
                 .SetupGet(mock => mock.AccessToken)
-                .Returns(ACCES_TOKEN);
+                .Returns(AccessToken);
 
             credentialsMock
                 .SetupGet(mock => mock.TokenType)

--- a/Bynder/Test/Api/RequestSender/HttpRequestSenderTest.cs
+++ b/Bynder/Test/Api/RequestSender/HttpRequestSenderTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Bynder. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -20,6 +21,10 @@ namespace Bynder.Test.Api.RequestSender
             {
                 HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, httpListener.ListeningUrl);
                 var response = await httpRequestSender.SendHttpRequest(requestMessage);
+                Assert.Equal(
+                    httpRequestSender.UserAgent,
+                    response.RequestMessage.Headers.GetValues("User-Agent").First()
+                );
 
             }
         }

--- a/Bynder/Test/Api/RequestSender/HttpRequestSenderTest.cs
+++ b/Bynder/Test/Api/RequestSender/HttpRequestSenderTest.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Bynder.Sdk.Api.RequestSender;
 using Bynder.Test.Utils;
 using Xunit;
@@ -12,16 +13,26 @@ namespace Bynder.Test.Api.RequestSender
     public class HttpRequestSenderTest
     {
         [Fact]
-        public void WhenErrorReceivedAnExceptionIsThown()
+        public async Task WhenSuccessReceivedResponseIsReturned()
         {
-            using (var testHttpListener = new TestHttpListener(HttpStatusCode.Forbidden, null))
+            using (var httpListener = new TestHttpListener(HttpStatusCode.OK))
+            using (var httpRequestSender = new HttpRequestSender())
             {
-                using (HttpRequestSender apiRequestSender = new HttpRequestSender())
-                {
-                    HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, testHttpListener.ListeningUrl);
+                HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, httpListener.ListeningUrl);
+                var response = await httpRequestSender.SendHttpRequest(requestMessage);
 
-                    Assert.ThrowsAsync<HttpRequestException>(async () => await apiRequestSender.SendHttpRequest(requestMessage));
-                }
+            }
+        }
+        [Fact]
+        public async Task WhenErrorReceivedAnExceptionIsThown()
+        {
+            using (var httpListener = new TestHttpListener(HttpStatusCode.Forbidden))
+            using (var httpRequestSender = new HttpRequestSender())
+            {
+                HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, httpListener.ListeningUrl);
+                var doRequest = httpRequestSender.SendHttpRequest(requestMessage);
+
+                await Assert.ThrowsAsync<HttpRequestException>(() => doRequest);
             }
         }
     }

--- a/Bynder/Test/Api/RequestSender/HttpRequestSenderTest.cs
+++ b/Bynder/Test/Api/RequestSender/HttpRequestSenderTest.cs
@@ -19,8 +19,9 @@ namespace Bynder.Test.Api.RequestSender
             using (var httpListener = new TestHttpListener(HttpStatusCode.OK))
             using (var httpRequestSender = new HttpRequestSender())
             {
-                HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, httpListener.ListeningUrl);
+                var requestMessage = new HttpRequestMessage(HttpMethod.Get, httpListener.ListeningUrl);
                 var response = await httpRequestSender.SendHttpRequest(requestMessage);
+
                 Assert.Equal(
                     httpRequestSender.UserAgent,
                     response.RequestMessage.Headers.GetValues("User-Agent").First()
@@ -34,7 +35,7 @@ namespace Bynder.Test.Api.RequestSender
             using (var httpListener = new TestHttpListener(HttpStatusCode.Forbidden))
             using (var httpRequestSender = new HttpRequestSender())
             {
-                HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, httpListener.ListeningUrl);
+                var requestMessage = new HttpRequestMessage(HttpMethod.Get, httpListener.ListeningUrl);
                 var doRequest = httpRequestSender.SendHttpRequest(requestMessage);
 
                 await Assert.ThrowsAsync<HttpRequestException>(() => doRequest);

--- a/Bynder/Test/Utils/TestHttpListener.cs
+++ b/Bynder/Test/Utils/TestHttpListener.cs
@@ -23,6 +23,11 @@ namespace Bynder.Test.Utils
         /// <summary>
         /// Path of the file which contents will be the response to requests.
         /// </summary>
+        private readonly string _responseContent;
+
+        /// <summary>
+        /// Path of the file which contents will be the response to requests.
+        /// </summary>
         private readonly string _responsePath;
 
         /// <summary>
@@ -37,11 +42,13 @@ namespace Bynder.Test.Utils
         /// Creates an instance of the class.
         /// </summary>
         /// <param name="statusCode">HTTP status code that the class will return when having requests</param>
+        /// <param name="responseContent">String whose contents the class will return in the response</param>
         /// <param name="responsePath">File whose contents the class will return in the response</param>
-        public TestHttpListener(HttpStatusCode statusCode, string responsePath)
+        public TestHttpListener(HttpStatusCode statusCode, string responseContent = null, string responsePath = null)
         {
-            _responsePath = responsePath;
             _statusCode = statusCode;
+            _responseContent = responseContent;
+            _responsePath = responsePath;
 
             _httpListenerFactory = new HttpListenerFactory();
 
@@ -97,7 +104,15 @@ namespace Bynder.Test.Utils
         {
             response.StatusCode = (int)_statusCode;
 
-            if (!string.IsNullOrEmpty(_responsePath))
+            if (!string.IsNullOrEmpty(_responseContent))
+            {
+                using (var sw = new StreamWriter(response.OutputStream))
+                {
+                    sw.Write(_responseContent);
+                }
+            }
+
+            else if (!string.IsNullOrEmpty(_responsePath))
             {
                 var dr = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
                 using (var fs = new FileStream(Path.Combine(dr, _responsePath), FileMode.Open, FileAccess.Read))


### PR DESCRIPTION
Adds the SDK's name and version to each request in the User-Agent header, to enable better insight in the Bynder API usage.