### PR TITLE
API-515 - [C# SDK] Downgrade .NET standard from 2.1 to 2.0

### DIFF
--- a/Bynder/Sample/Bynder.Sample.csproj
+++ b/Bynder/Sample/Bynder.Sample.csproj
@@ -9,7 +9,7 @@
     <Copyright>Copyright © Bynder</Copyright>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sdk\Bynder.Sdk.csproj" />

--- a/Bynder/Sdk/Api/Converters/TagsOrderByConverter.cs
+++ b/Bynder/Sdk/Api/Converters/TagsOrderByConverter.cs
@@ -20,13 +20,20 @@ namespace Bynder.Sdk.Api.Converters
         /// </summary>
         /// <param name="value">TagsOrderBy value</param>
         /// <returns>converted string</returns>
-        public string Convert(object value) => value switch
+        public string Convert(object value)
         {
-            TagsOrderBy.TagAscending => "tag asc",
-            TagsOrderBy.TagDescending => "tag desc",
-            TagsOrderBy.MediaCountAscending => "mediaCount asc",
-            TagsOrderBy.MediaCountDescending => "mediaCount desc",
-            _ => null,
-        };
+            switch (value) {
+                case TagsOrderBy.TagAscending:
+                    return "tag asc";
+                case TagsOrderBy.TagDescending:
+                    return "tag desc";
+                case TagsOrderBy.MediaCountAscending:
+                    return "mediaCount asc";
+                case TagsOrderBy.MediaCountDescending:
+                    return "mediaCount desc";
+                default:
+                    return null;
+            }
+        }
     }
 }

--- a/Bynder/Sdk/Bynder.Sdk.csproj
+++ b/Bynder/Sdk/Bynder.Sdk.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyVersion>2.2.4.0</AssemblyVersion>
     <FileVersion>2.2.4.0</FileVersion>
     <Company>Bynder</Company>

--- a/Bynder/Sdk/Bynder.Sdk.csproj
+++ b/Bynder/Sdk/Bynder.Sdk.csproj
@@ -29,7 +29,7 @@ Fixed an incorrect type in the media response body (issue #48).</PackageReleaseN
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Bynder/Test/Bynder.Test.csproj
+++ b/Bynder/Test/Bynder.Test.csproj
@@ -9,13 +9,13 @@
     <Copyright>Copyright © Bynder</Copyright>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.2"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Moq.Sequences" Version="2.2.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Downgraded .NET standard from 2.1 back to 2.0, to ensure compatibility with .NET framework.