### PR TITLE
added support for .net framework 4.x

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '5.0.x'
       - name: Build
         run: dotnet build --configuration Release
 
@@ -36,7 +36,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '5.0.x'
 
       - name: Install dependencies
         run: dotnet restore

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '5.0.x'
       - name: Build
         run: dotnet build --configuration Release
 

--- a/Bynder/Sdk/Bynder.Sdk.csproj
+++ b/Bynder/Sdk/Bynder.Sdk.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyVersion>2.2.4.0</AssemblyVersion>
     <FileVersion>2.2.4.0</FileVersion>
     <Company>Bynder</Company>
@@ -25,10 +25,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bynder/Sdk/Bynder.Sdk.csproj
+++ b/Bynder/Sdk/Bynder.Sdk.csproj
@@ -21,6 +21,7 @@
     <PackageTags>Bynder API C# SDK</PackageTags>
     <Title>Bynder.Sdk</Title>
     <PackageId>Bynder.Sdk</PackageId>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />

--- a/Bynder/Sdk/Bynder.Sdk.nuspec
+++ b/Bynder/Sdk/Bynder.Sdk.nuspec
@@ -15,4 +15,7 @@
     <copyright>Copyright © Bynder</copyright>
     <tags>Bynder API C# SDK</tags>
   </metadata>
+  <files>
+    <file src=".\**" target="lib/{framework name}[{version}]" />
+  </files>
 </package>

--- a/Bynder/Test/Bynder.Test.csproj
+++ b/Bynder/Test/Bynder.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <AssemblyVersion>2.0.0</AssemblyVersion>
     <FileVersion>2.0.0</FileVersion>


### PR DESCRIPTION
When using the Bynder SDK with a .NET Framework project, all the dll's from .NET Standard runtime are also included causing unwanted issues.

Modifying the nuspec and csproj files allows us to get the Bynder SDK to work nicely with .NET Framework 4.x

**Sources:**

- https://weblog.west-wind.com/posts/2019/Feb/19/Using-NET-Standard-with-Full-Framework-NET#what-a-difference-a-runtime-makes
- https://blog.tdwright.co.uk/2017/11/21/update-getting-net-standard-apps-playing-nicely-on-nuget/
