### PR TITLE
fixed issue with use of relative url's

### DIFF
--- a/Bynder/Sdk/Api/RequestSender/ApiRequestSender.cs
+++ b/Bynder/Sdk/Api/RequestSender/ApiRequestSender.cs
@@ -132,10 +132,7 @@ namespace Bynder.Sdk.Api.RequestSender
             internal static HttpRequestMessage Create(
                 string baseUrl, HttpMethod method, IDictionary<string, string> requestParams, string urlPath)
             {
-                var builder = new UriBuilder(baseUrl)
-                {
-                    Path = urlPath
-                };
+                var builder = new UriBuilder(Utils.Url.MergeBaseUrlAndRelativePath(baseUrl, urlPath));
 
                 if (HttpMethod.Get == method)
                 {

--- a/Bynder/Sdk/Utils/Url.cs
+++ b/Bynder/Sdk/Utils/Url.cs
@@ -26,5 +26,19 @@ namespace Bynder.Sdk.Utils
 
             return queryUri;
         }
+
+        /// <summary>
+        /// Merges BaseUrl with a RelativePath
+        /// </summary>
+        /// <param name="baseUrl">The baseUrl of the request</param>
+        /// <param name="urlPath">The relative url of the request</param>
+        /// <returns>A valid uri merge the base and the relative uri</returns>
+        public static Uri MergeBaseUrlAndRelativePath(string baseUrl, string urlPath)
+        {
+            // for the relative url to be merged correctly the following must be true
+            // base url should always end with /
+            // relative url should never begin with a /
+            return new Uri(new Uri(baseUrl.TrimEnd('/')+"/"), urlPath.TrimStart('/'));
+        }
     }
 }

--- a/Bynder/Test/Utils/UrlTest.cs
+++ b/Bynder/Test/Utils/UrlTest.cs
@@ -27,5 +27,14 @@ namespace Bynder.Test.Utils
         {
             Assert.Empty(Url.ConvertToQuery(new Dictionary<string, string>()));
         }
+        
+        [Fact]
+        public void MergeBaseUrlWithRelativePath()
+        {
+            var uriWithDirectDomain = Url.MergeBaseUrlAndRelativePath("https://test.getbynder.com", "/api/v4/some-api-method");
+            Assert.Equal("https://test.getbynder.com/api/v4/some-api-method", uriWithDirectDomain.ToString());
+            var uriWithDirectory = Url.MergeBaseUrlAndRelativePath("https://test.mydomain.com/bynder", "/api/v4/some-api-method");
+            Assert.Equal("https://test.mydomain.com/bynder/api/v4/some-api-method", uriWithDirectory.ToString());
+        }
     }
 }


### PR DESCRIPTION
If you are accessing bynder behind an API Gateway or a Proxy then the relative urls for API Calls are not combined properly.

**Example**
_BaseUrl_: https://test.company.com/bynder
_UrlPath_: /api/v4/example
_Expected http call_: https://test.company.com/bynder/api/v4/example
_Actual http call:_         https://test.company.com/api/v4/example

It was assumed to be fixed in the latest version of the SDK but unfortunately that's not the case :(
