### PR TITLE
Fix url path appending

### DIFF
--- a/Bynder/Sdk/Api/RequestSender/ApiRequestSender.cs
+++ b/Bynder/Sdk/Api/RequestSender/ApiRequestSender.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Bynder.Sdk.Api.Requests;
+using Bynder.Sdk.Extensions;
 using Bynder.Sdk.Query.Decoder;
 using Bynder.Sdk.Service.OAuth;
 using Bynder.Sdk.Settings;
@@ -132,10 +133,7 @@ namespace Bynder.Sdk.Api.RequestSender
             internal static HttpRequestMessage Create(
                 string baseUrl, HttpMethod method, IDictionary<string, string> requestParams, string urlPath)
             {
-                var builder = new UriBuilder(baseUrl)
-                {
-                    Path = urlPath
-                };
+                var builder = new UriBuilder(baseUrl).AppendPath(urlPath);
 
                 if (HttpMethod.Get == method)
                 {

--- a/Bynder/Sdk/Bynder.Sdk.csproj
+++ b/Bynder/Sdk/Bynder.Sdk.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>
-    <AssemblyVersion>2.2.6.0</AssemblyVersion>
-    <FileVersion>2.2.6.0</FileVersion>
+    <AssemblyVersion>2.2.7.0</AssemblyVersion>
+    <FileVersion>2.2.7.0</FileVersion>
     <Company>Bynder</Company>
     <Product>Bynder.Sdk</Product>
     <Copyright>Copyright © Bynder</Copyright>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>2.2.6</PackageVersion>
+    <PackageVersion>2.2.7</PackageVersion>
     <Authors>BynderDevops</Authors>
     <Description>The main goal of this SDK is to speed up the integration of Bynder customers who use C# making it easier to connect to the Bynder API (http://docs.bynder.apiary.io/) and executing requests on it.</Description>
     <PackageIconUrl>https://bynder.com/static/3.0/img/favicon-black.ico</PackageIconUrl>
@@ -16,7 +16,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Owners>BynderDevops</Owners>
     <PackageProjectUrl>https://github.com/Bynder/bynder-c-sharp-sdk</PackageProjectUrl>
-    <PackageReleaseNotes>Added .NET framework as a separate target.</PackageReleaseNotes>
+    <PackageReleaseNotes>Resolved an issue regarding the construction of API urls.</PackageReleaseNotes>
     <Summary>The main goal of this SDK is to speed up the integration of Bynder customers who use C# making it easier to connect to the Bynder API (http://docs.bynder.apiary.io/) and executing requests on it.</Summary>
     <PackageTags>Bynder API C# SDK</PackageTags>
     <Title>Bynder.Sdk</Title>

--- a/Bynder/Sdk/Extensions/UriBuilderExtensions.cs
+++ b/Bynder/Sdk/Extensions/UriBuilderExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Bynder.Sdk.Extensions
+{
+    public static class UriBuilderExtensions
+    {
+        /// <summary>
+        /// Allows to append a path to a url without overriding the existing path
+        /// (which happens when you would set the Path property).
+        ///
+        /// For example, UriBuilder("https://example.com/base") { Path = "path/to/something" }
+        /// will result in "https://example.com/path/to/something" (removing the "base" part)
+        ///
+        /// While UriBuilder("https://example.com/base").AppendPath("path/to/something")
+        /// will result in "https://example.com/base/path/to/something"
+        ///
+        /// It will automatically ensure that the paths are combined correctly using only one "/".
+        /// </summary>
+        /// <param name="uriBuilder">extended UriBuilder instance</param>
+        /// <param name="path">path to be appended to the full url</param>
+        /// <returns>UriBuilder instance with the appended path</returns>
+        public static UriBuilder AppendPath(this UriBuilder uriBuilder, String path)
+        {
+            uriBuilder.Path = $"{uriBuilder.Path.TrimEnd('/')}/{path.TrimStart('/')}";
+            return uriBuilder;
+        }
+    }
+}

--- a/Bynder/Sdk/Service/OAuth/OAuthService.cs
+++ b/Bynder/Sdk/Service/OAuth/OAuthService.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Bynder.Sdk.Api.Requests;
 using Bynder.Sdk.Api.RequestSender;
+using Bynder.Sdk.Extensions;
 using Bynder.Sdk.Model;
 using Bynder.Sdk.Query;
 using Bynder.Sdk.Settings;
@@ -48,7 +49,6 @@ namespace Bynder.Sdk.Service.OAuth
 
             return new UriBuilder(_configuration.BaseUrl)
             {
-                Path = AuthPath,
                 Query = Utils.Url.ConvertToQuery(
                     new Dictionary<string, string>
                     {
@@ -59,7 +59,7 @@ namespace Bynder.Sdk.Service.OAuth
                         { "state", state }
                     }
                 )
-            }.ToString();
+            }.AppendPath(AuthPath).ToString();
         }
 
         /// <summary>

--- a/Bynder/Test/Extensions/UriBuilderExtensionsTest.cs
+++ b/Bynder/Test/Extensions/UriBuilderExtensionsTest.cs
@@ -1,0 +1,20 @@
+using System;
+using Bynder.Sdk.Extensions;
+using Xunit;
+
+namespace Bynder.Test.Extensions
+{
+    public class UriBuilderExtensionsTest
+    {
+        [Fact]
+        public void PathsAreCorrectlyAppended()
+        {
+            var expectedUrl = "https://example.com:443/base/path/to/something";
+            Assert.Equal(expectedUrl, new UriBuilder("https://example.com/base").AppendPath("path/to/something").ToString());
+            Assert.Equal(expectedUrl, new UriBuilder("https://example.com/base").AppendPath("/path/to/something").ToString());
+            Assert.Equal(expectedUrl, new UriBuilder("https://example.com/base/").AppendPath("path/to/something").ToString());
+            Assert.Equal(expectedUrl, new UriBuilder("https://example.com/base/").AppendPath("/path/to/something").ToString());
+        }
+    }
+
+}


### PR DESCRIPTION
Builds upon the work done in https://github.com/Bynder/bynder-c-sharp-sdk/pull/60

Resolves the issue where a configuration with certain base URLs would not result in the desired url when a path was added to it. For example: "https://example.com/base" & "/path/to/something" would result in "https://example.com/path/to/something" (with the "base" part removed).