### PR TITLE
Downgraded Newtonsoft.Json to 11.0.2 for compatibility with Sitecore 9.3

### DIFF
--- a/Bynder/Sdk/Bynder.Sdk.csproj
+++ b/Bynder/Sdk/Bynder.Sdk.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
The SDK itself does not require a higher version of Newtonsoft.Json, so it doesn't seem a problem to downgrade.
It also doesn't affect projects that rely on a higher version because the SDK will still function if a higher version of Newtonsoft.Json is present.