### PR TITLE
Simplified Asset Service to use Stream instead of FileStream

### DIFF
--- a/Bynder/Sdk/Service/Asset/AssetService.cs
+++ b/Bynder/Sdk/Service/Asset/AssetService.cs
@@ -151,7 +151,7 @@ namespace Bynder.Sdk.Service.Asset
         /// <param name="fileStream">Check <see cref="IAssetService"/> for more information</param>
         /// <param name="query">Check <see cref="IAssetService"/> for more information</param>
         /// <returns>Check <see cref="IAssetService"/> for more information</returns>
-        public async Task<SaveMediaResponse> UploadFileAsync(FileStream fileStream, UploadQuery query)
+        public async Task<SaveMediaResponse> UploadFileAsync(Stream fileStream, UploadQuery query)
         {
             return await _uploader.UploadFileAsync(fileStream, query).ConfigureAwait(false);
         }

--- a/Bynder/Sdk/Service/Asset/IAssetService.cs
+++ b/Bynder/Sdk/Service/Asset/IAssetService.cs
@@ -92,7 +92,7 @@ namespace Bynder.Sdk.Service.Asset
         /// <exception cref="HttpRequestException">Can be thrown when requests to server can't be completed or HTTP code returned by server is an error</exception>
         /// <exception cref="BynderUploadException">Can be thrown when upload does not finish within expected time</exception>
 
-        Task<SaveMediaResponse> UploadFileAsync(FileStream fileStream, UploadQuery query);
+        Task<SaveMediaResponse> UploadFileAsync(Stream fileStream, UploadQuery query);
 
 
         /// <summary>


### PR DESCRIPTION
Simplified `AssetService` to use `Stream` instead of `FileStream` for file uploading since only the `Stream` base type is used further.

`AssetService` uses `FileUploader` for file uploading.
`FileUploader` expects `Stream` as first input parameter type when `AssetService` expects `FileStream` as first input parameter type.
`AssetService` doesn't use any features of the `FileStream` and can be simplified to use `Stream` as an first input parameter type.

This change should be useful in case of using Bynder SDK in clouds for serverless applications when there are limits on available disk space (for `FileStream` it's necessary to have file on the disk).