### PR TITLE
Add Docker support for running samples

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/.vs/
+**/.vscode/
+**/bin/
+**/obj/
+**/.git/
+**/Bynder/Sample/Config.json

--- a/Bynder/Sample/Bynder.Sample.csproj
+++ b/Bynder/Sample/Bynder.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyVersion>2.0.0</AssemblyVersion>
     <FileVersion>2.0.0</FileVersion>
     <Company>Bynder</Company>

--- a/Config.json
+++ b/Config.json
@@ -3,5 +3,5 @@
   "client_id": "your oauth app client id",
   "client_secret": "your oauth app client secret",
   "redirect_uri": "your oauth app redirect uri",
-  "scopes": "offline asset:read asset:write collection:read"
+  "scopes": "offline asset:read asset:write collection:read collection:write asset.usage:read asset.usage:write meta.assetbank:read meta.assetbank:write meta.workflow:read"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/dotnet/sdk:9.0
+
+WORKDIR /app
+
+COPY . .
+
+RUN dotnet build Bynder/Sample/Bynder.Sample.csproj
+
+# Simple entrypoint to keep container running
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: run-docker stop-docker executeSdkSample rebuild-container
+run-docker:
+	docker-compose up -d
+
+stop-docker:
+	docker-compose down
+
+executeSdkSample:
+	docker-compose exec bynder-sdk dotnet run --project Bynder/Sample/Bynder.Sample.csproj -- $(sample-name)
+
+rebuild-container:
+	docker-compose build
+	docker-compose up -d
+
+rebuild-project:
+	docker-compose exec bynder-sdk dotnet build Bynder/Sample/Bynder.Sample.csproj

--- a/README.md
+++ b/README.md
@@ -180,3 +180,58 @@ dotnet run -- AssetUsage
 Methods Used:
 * CreateAssetUsage(AssetUsageQuery)
 * DeleteAssetUsage(AssetUsageQuery)
+
+## Running Sample Files Using Docker
+
+If you want to avoid .NET version compatibility issues or simplify the setup process, you can use Docker to run the sample files.
+
+### Prerequisites
+
+- [Docker](https://www.docker.com/get-started) installed on your machine
+- [Docker Compose](https://docs.docker.com/compose/install/) installed on your machine
+
+### Setting up Docker Environment
+
+##### 1. Create a `Config.json` file in the repository root with your Bynder credentials:
+
+```json
+{
+  "base_url": "https://example.bynder.com",
+  "client_id": "your oauth app client id",
+  "client_secret": "your oauth app client secret",
+  "redirect_uri": "your oauth app redirect uri",
+  "scopes": "offline asset:read asset:write collection:read collection:write asset.usage:read asset.usage:write meta.assetbank:read meta.assetbank:write meta.workflow:read"
+}
+```
+
+##### 2. Start the Docker container:
+
+`make run-docker`
+
+##### 3. Run any sample using the make command:
+
+`make executeSdkSample sample-name=BrandsSample`
+
+Available sample names:
+
+* BrandsSample
+* MetapropertiesSample
+* MetapropertyToMediaSample
+* MediaSample
+* FindMediaSample
+* ModifyMediaSample
+* CollectionsSample
+* TagsSample
+* UploadSample
+* AssetUsageSample
+
+##### 4. When you're done, stop the Docker container:
+`make stop-docker`
+
+If you make changes to the code, you can rebuild the project within the container:
+
+`make rebuild-project`
+
+Or rebuild the entire container if needed:
+
+`make rebuild-container`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  bynder-sdk:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    network_mode: host 
+    volumes:
+      - .:/app
+      - ~/.nuget:/root/.nuget
+    environment:
+      - DOTNET_ENVIRONMENT=Development


### PR DESCRIPTION
# Add Docker Support for Running Samples

## Overview
This PR adds Docker support to the Bynder C# SDK, making it easier to run sample files without dealing with .NET version compatibility issues or complex environment setup.

## Changes Made
- Added `Dockerfile` to create a container with .NET SDK 9.0
- Created `docker-compose.yml` to define service configuration
- Added `Makefile` with commands to simplify Docker operations
- Updated `README.md` with documentation on using Docker

## Benefits
- Eliminates the need to install specific .NET versions on the host machine
- Provides consistent development environment across different platforms
- Simplifies running sample files with a standardized command structure
- Makes testing SDK functionality faster and more accessible

## How to Use
Simply follow the instructions in the README.md:
1. Create a `Config.json` file with Bynder credentials
2. Run `make run-docker` to start the container
3. Execute samples with `make executeSdkSample sample-name=BrandsSample`
4. When finished, run `make stop-docker`

## Testing Done
Successfully tested running all sample files through Docker on macOS.