### PR TITLE
Bugfix: Correct File Chunk Stream Reading

### DIFF
--- a/Bynder/Sdk/Service/Asset/AssetService.cs
+++ b/Bynder/Sdk/Service/Asset/AssetService.cs
@@ -156,6 +156,17 @@ namespace Bynder.Sdk.Service.Asset
             return await _uploader.UploadFileAsync(fileStream, query).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Check <see cref="IAssetService"/> for more information
+        /// </summary>
+        /// <param name="fileStream">Check <see cref="IAssetService"/> for more information</param>
+        /// <param name="fileStreamLength">Length of the file stream</param>
+        /// <param name="query">Check <see cref="IAssetService"/> for more information</param>
+        /// <returns>Check <see cref="IAssetService"/> for more information</returns>
+        public async Task<SaveMediaResponse> UploadFileAsync(Stream fileStream, long fileStreamLength, UploadQuery query)
+        {
+            return await _uploader.UploadFileAsync(fileStream, fileStreamLength, query).ConfigureAwait(false);
+        }
 
         /// <summary>
         /// Check <see cref="IAssetService"/> for more information

--- a/Bynder/Sdk/Service/Asset/IAssetService.cs
+++ b/Bynder/Sdk/Service/Asset/IAssetService.cs
@@ -94,6 +94,14 @@ namespace Bynder.Sdk.Service.Asset
 
         Task<SaveMediaResponse> UploadFileAsync(Stream fileStream, UploadQuery query);
 
+        /// <summary>
+        /// Uploads a file as a stream
+        /// </summary>
+        /// <param name="fileStream">Stream representing the file to be uploaded</param>
+        /// <param name="fileStreamLength">Length of the file stream, to be used if the stream doesn't define it</param>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        Task<SaveMediaResponse> UploadFileAsync(Stream fileStream, long fileStreamLength, UploadQuery query);
 
         /// <summary>
         /// Modifies a media

--- a/Bynder/Sdk/Service/Upload/FileUploader.cs
+++ b/Bynder/Sdk/Service/Upload/FileUploader.cs
@@ -80,7 +80,19 @@ namespace Bynder.Sdk.Service.Upload
         /// <returns>Task representing the upload</returns>
         public async Task<SaveMediaResponse> UploadFileAsync(Stream fileStream, UploadQuery query)
         {
-            return await UploadFileAsync(fileStream, query, query.OriginalFileName ?? Path.GetFileName(query.Filepath));
+            return await UploadFileAsync(fileStream, fileStream.Length, query);
+        }
+
+        /// <summary>
+        /// Uploads a file with the data specified in query parameter
+        /// </summary>
+        /// <param name="fileStream">Stream of the file to upload</param>
+        /// <param name="fileStreamLength">Length of the file stream</param>
+        /// <param name="query">Upload query information to upload a file</param>
+        /// <returns>Task representing the upload</returns>
+        public async Task<SaveMediaResponse> UploadFileAsync(Stream fileStream, long fileStreamLength, UploadQuery query)
+        {
+            return await UploadFileAsync(fileStream, fileStreamLength, query, query.OriginalFileName ?? Path.GetFileName(query.Filepath));
         }
 
         /// <summary>
@@ -96,9 +108,7 @@ namespace Bynder.Sdk.Service.Upload
             uint chunkNumber = 0;
 
             var fileStream = File.Open(query.Filepath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-            return await UploadFileAsync(fileStream, query, filename);
-
-            
+            return await UploadFileAsync(fileStream, fileStream.Length, query, filename);
         }
 
         private async Task<UploadRequest> GetUploadRequest(string fileName)
@@ -106,8 +116,7 @@ namespace Bynder.Sdk.Service.Upload
             return await RequestUploadInformationAsync(new RequestUploadQuery { Filename = fileName }).ConfigureAwait(false);
         }
 
-
-        private async Task<SaveMediaResponse> UploadFileAsync(Stream fileStream, UploadQuery query, string filename)
+        private async Task<SaveMediaResponse> UploadFileAsync(Stream fileStream, long fileStreamLength, UploadQuery query, string filename)
         {
             uint chunkNumber = 0;
             var uploadRequest = await GetUploadRequest(filename);
@@ -115,12 +124,12 @@ namespace Bynder.Sdk.Service.Upload
             await using (fileStream)
             {
                 byte[] buffer = new byte[CHUNK_SIZE];
-                long numberOfChunks = (fileStream.Length + buffer.Length - 1) / buffer.Length;
+                long numberOfChunks = (fileStreamLength + buffer.Length - 1) / buffer.Length;
                 long totalBytesRead = 0;
 
-                while (totalBytesRead < fileStream.Length)
+                while (totalBytesRead < fileStreamLength)
                 {
-                    int bytesToRead = (int)Math.Min(buffer.Length, fileStream.Length - totalBytesRead);
+                    int bytesToRead = (int)Math.Min(buffer.Length, fileStreamLength - totalBytesRead);
 
                     await UploadChunkAsync(uploadRequest, filename, fileStream, buffer, bytesToRead, numberOfChunks, ++chunkNumber);
 

--- a/Bynder/Sdk/Service/Upload/FileUploader.cs
+++ b/Bynder/Sdk/Service/Upload/FileUploader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Bynder. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -110,16 +111,20 @@ namespace Bynder.Sdk.Service.Upload
         {
             uint chunkNumber = 0;
             var uploadRequest = await GetUploadRequest(filename);
-            using (fileStream)
-            {
-                int bytesRead = 0;
-                var buffer = new byte[CHUNK_SIZE];
-                long numberOfChunks = (fileStream.Length + CHUNK_SIZE - 1) / CHUNK_SIZE;
 
-                while ((bytesRead = fileStream.Read(buffer, 0, buffer.Length)) > 0)
+            await using (fileStream)
+            {
+                byte[] buffer = new byte[CHUNK_SIZE];
+                long numberOfChunks = (fileStream.Length + buffer.Length - 1) / buffer.Length;
+                long totalBytesRead = 0;
+
+                while (totalBytesRead < fileStream.Length)
                 {
-                    ++chunkNumber;
-                    await UploadPartAsync(Path.GetFileName(query.Filepath), buffer, bytesRead, chunkNumber, uploadRequest, (uint)numberOfChunks).ConfigureAwait(false);
+                    int bytesToRead = (int)Math.Min(buffer.Length, fileStream.Length - totalBytesRead);
+
+                    await UploadChunkAsync(uploadRequest, filename, fileStream, buffer, bytesToRead, numberOfChunks, ++chunkNumber);
+
+                    totalBytesRead += bytesToRead;
                 }
             }
 
@@ -145,6 +150,25 @@ namespace Bynder.Sdk.Service.Upload
             {
                 throw new BynderUploadException("Converter did not finish. Upload not completed");
             }
+        }
+
+        private async Task UploadChunkAsync(UploadRequest uploadRequest, string fileName, Stream fileStream, byte[] buffer, int bytesToRead, long numberOfChunks, uint chunkNumber)
+        {
+            int bytesReadForChunk = 0;
+
+            while (bytesReadForChunk < bytesToRead)
+            {
+                int bytesRead = await fileStream.ReadAsync(buffer, bytesReadForChunk, bytesToRead - bytesReadForChunk);
+
+                if (bytesRead == 0)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                bytesReadForChunk += bytesRead;
+            }
+
+            await UploadPartAsync(fileName, buffer, bytesReadForChunk, chunkNumber, uploadRequest, (uint)numberOfChunks).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
This change fixes an issue where the file upload would not read and upload the file chunks correctly. The original code incorrectly assumes that `Stream.Read()` would always read a full chunk of data from the file stream, when in reality it may return read fewer bytes. To solve this, the new `UploadChunkAsync` helper method ensures the entire chunk is read from the stream before proceeding with the upload.